### PR TITLE
Idea for expanding Mod Options by having a screen per mod

### DIFF
--- a/src/main/java/org/legendofdragoon/modloader/controls/IWidgetOptions.java
+++ b/src/main/java/org/legendofdragoon/modloader/controls/IWidgetOptions.java
@@ -1,0 +1,6 @@
+package org.legendofdragoon.modloader.controls;
+
+public interface IWidgetOptions {
+    record DropDown(String[] options) implements IWidgetOptions { }
+    record Numeric<T extends Number> (T min, T max, T step) implements IWidgetOptions { }
+}

--- a/src/main/java/org/legendofdragoon/modloader/controls/ValueWatcher.java
+++ b/src/main/java/org/legendofdragoon/modloader/controls/ValueWatcher.java
@@ -1,0 +1,6 @@
+package org.legendofdragoon.modloader.controls;
+
+@FunctionalInterface
+public interface ValueWatcher<T> {
+    void onChange(T value);
+}

--- a/src/main/java/org/legendofdragoon/modloader/controls/Widget.java
+++ b/src/main/java/org/legendofdragoon/modloader/controls/Widget.java
@@ -1,0 +1,3 @@
+package org.legendofdragoon.modloader.controls;
+
+public record Widget<T>(WidgetType type, String name, T currentValue, IWidgetOptions options, ValueWatcher<T> valueWatcher) { }

--- a/src/main/java/org/legendofdragoon/modloader/controls/WidgetFactory.java
+++ b/src/main/java/org/legendofdragoon/modloader/controls/WidgetFactory.java
@@ -1,0 +1,27 @@
+package org.legendofdragoon.modloader.controls;
+
+public final class WidgetFactory {
+    private WidgetFactory() {}
+
+    public static Widget<String> newLabel(final String text) {
+        return new Widget<String>(WidgetType.Label, text, null,null, null);
+    }
+    public static Widget<Boolean> newButton(final String name, final Boolean current, final ValueWatcher<Boolean> onClick) {
+        return new Widget<>(WidgetType.Button, name, current, null, onClick);
+    }
+    public static Widget<Boolean> newCheckbox(final String name, final Boolean current, final ValueWatcher<Boolean> onClick) {
+        return new Widget<>(WidgetType.Checkbox, name, current, null, onClick);
+    }
+    public static Widget<String> newTextbox(final String name, final String current, final ValueWatcher<String> onChange) {
+        return new Widget<>(WidgetType.Textbox, name, current, null, onChange);
+    }
+    public static Widget<String> newDropdown(final String name, final String[] options, final String current, final ValueWatcher<String> onChange) {
+        return new Widget<>(WidgetType.Dropdown, name, current, new IWidgetOptions.DropDown(options), onChange);
+    }
+    public static Widget<Integer> newInteger(final String name, final int min, final int max, final int step, final int current, final ValueWatcher<Integer> onChange) {
+        return new Widget<>(WidgetType.Numeric, name, current, new IWidgetOptions.Numeric<>(min, max, step), onChange);
+    }
+    public static Widget<Float> newFloat(final String name,final  float min, final float max, final float step, final float current, final ValueWatcher<Float> onChange) {
+        return new Widget<>(WidgetType.Numeric, name, current, new IWidgetOptions.Numeric<>(min, max, step), onChange);
+    }
+}

--- a/src/main/java/org/legendofdragoon/modloader/controls/WidgetType.java
+++ b/src/main/java/org/legendofdragoon/modloader/controls/WidgetType.java
@@ -1,0 +1,11 @@
+package org.legendofdragoon.modloader.controls;
+
+public enum WidgetType {
+    Numeric,
+    Checkbox,
+    Textbox,
+    Dropdown,
+    Button,
+    Label,
+
+}

--- a/src/main/java/org/legendofdragoon/modloader/controls/package-info.java
+++ b/src/main/java/org/legendofdragoon/modloader/controls/package-info.java
@@ -1,0 +1,1 @@
+package org.legendofdragoon.modloader.controls;

--- a/src/main/java/org/legendofdragoon/modloader/options/ModOptions.java
+++ b/src/main/java/org/legendofdragoon/modloader/options/ModOptions.java
@@ -1,0 +1,10 @@
+package org.legendofdragoon.modloader.options;
+
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ModOptions {
+    OptionsType storageLocation();
+}

--- a/src/main/java/org/legendofdragoon/modloader/options/Options.java
+++ b/src/main/java/org/legendofdragoon/modloader/options/Options.java
@@ -1,0 +1,49 @@
+package org.legendofdragoon.modloader.options;
+
+import org.legendofdragoon.modloader.controls.Widget;
+
+import java.util.List;
+
+public abstract class Options<T> { // Will need to implement Screen
+    /**
+     * The options that were loaded and will be saved.
+     */
+    protected T options;
+
+    /**
+     * Called after `load` and prior to the option screen is displayed.
+     */
+    public void setupScreen() {};
+    /**
+     * Called after the user leaves the option screen but before `save` is called.
+     */
+    public void teardownScreen() {};
+    /**
+     * Called each time the display needs to be displayed.
+     */
+    public abstract List<Widget<?>> display();
+
+    /**
+     * Creates a new instance of the options.
+     * @return The new instance of the options.
+     */
+    public abstract T newOptions();
+
+    /**
+     * Converts the options to a byte array.
+     * @return The byte array representing the options.
+     */
+    public byte[] save() {
+        // TODO
+        return null;
+    }
+
+    /**
+     * Loads the options from a byte array.
+     * @param data The byte array representing the options.
+     */
+    public void load(byte[] data) {
+        this.options = this.newOptions();
+        // TODO
+    }
+}

--- a/src/main/java/org/legendofdragoon/modloader/options/OptionsType.java
+++ b/src/main/java/org/legendofdragoon/modloader/options/OptionsType.java
@@ -1,0 +1,6 @@
+package org.legendofdragoon.modloader.options;
+
+public enum OptionsType {
+    CAMPAIGN,
+    GLOBAL;
+}


### PR DESCRIPTION
Exploring this idea from discussion: https://github.com/Legend-of-Dragoon-Modding/Legend-of-Dragoon-Java/discussions/1054

This PR abstracts the definition of a `screen` and `inputs` so that the mod-loader does not need to know SC code.
The idea here is SC code will read in the ModOption's Display's return and convert the Widgets into their respective controls.

Packages:
- `controls` defines the possible Widgets
- `options` defines the annotation and abstract ModOptions which a modder can use to create a custom options window for their mod.